### PR TITLE
Throw `HTTPError` if status code is 403 Forbidden and fix tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,17 @@ function travisGot(path, opts) {
 		return got.stream(url, opts);
 	}
 
-	return got(url, opts);
+	return got(url, opts).catch(err => {
+		// In case of an invalid access token, Travis CI responds with
+		// 403 Forbidden and a non-JSON body which causes got to throw a ParseError
+		// instead of an HTTPError. To avoid this, we manually throw an HTTPError
+		// if the status code is 403 Forbidden.
+		if (err.statusCode !== 403) {
+			throw err;
+		}
+
+		throw new got.HTTPError(err.statusCode, err);
+	});
 }
 
 const helpers = [

--- a/test.js
+++ b/test.js
@@ -18,12 +18,12 @@ test('should accept options', async t => {
 
 test.serial('global token option', async t => {
 	process.env.TRAVIS_TOKEN = 'fail';
-	await t.throws(m('repos/SamVerschueren/travis-got'), 'Response code 401 (Unauthorized)');
+	await t.throws(m('repos/SamVerschueren/travis-got'), 'Response code 403 (Forbidden)');
 	process.env.TRAVIS_TOKEN = token;
 });
 
 test('token option', t => {
-	t.throws(m('repos/SamVerschueren/travis-got', {token: 'fail'}), 'Response code 401 (Unauthorized)');
+	t.throws(m('repos/SamVerschueren/travis-got', {token: 'fail'}), 'Response code 403 (Forbidden)');
 });
 
 test('endpoint option', t => {


### PR DESCRIPTION
In case of an invalid access token, Travis CI responds with `403 Forbidden` and a non-JSON body which causes got to throw a `ParseError` instead of an `HTTPError`. One way of fixing this would be to manually throw an `HTTPError` if the status code is `403 Forbidden`.

Furthermore, Travis CI now seems to respond with `403 Forbidden` instead of `401 Unauthorized`.

With these changes, the test suite is passing for me locally.